### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,4 +1,4 @@
 if not set -q aws_completer_path
-  set -g aws_completer_path (type -P aws_completer ^/dev/null)
+  set -g aws_completer_path (type -P aws_completer 2> /dev/null)
     or echo "aws: unable to find aws_completer, completions unavaliable"
 end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618