### PR TITLE
Complete profile when one command is in progress

### DIFF
--- a/completions/aws.fish
+++ b/completions/aws.fish
@@ -1,7 +1,3 @@
-function __aws_complete_root
-  test (count (commandline -o)) = 1
-end
-
 function __aws_complete
   if set -q aws_completer_path
     set -lx COMP_SHELL fish
@@ -12,5 +8,5 @@ function __aws_complete
 end
 
 complete --command aws --no-files --arguments '(__aws_complete)'
-complete --command aws --no-files --condition '__aws_complete_root' --arguments profile -d 'Get or set current profile'
+complete --command aws --no-files --condition 'test (count (commandline -opc)) -lt 2' --arguments profile -d 'Get or set current profile'
 complete --command aws --no-files --condition '__fish_seen_subcommand_from profile' --arguments '(aws profiles)'

--- a/completions/aws.fish
+++ b/completions/aws.fish
@@ -1,7 +1,11 @@
 function __aws_complete
   if set -q aws_completer_path
     set -lx COMP_SHELL fish
-    set -lx COMP_LINE (commandline)
+    set -lx COMP_LINE (commandline -opc)
+
+    if string match -q -- "-*" (commandline -opt)
+      set COMP_LINE $COMP_LINE -
+    end
 
     eval $aws_completer_path | command sed 's/ $//'
   end


### PR DESCRIPTION
Currently profile completes without arguments, but as soon as you have
written p and try to complete the completion will disappear and have no
match. This fixes this by also including it when a command is
provided and fish will filter it out if it does not match the current
token.

This allows for:
```fish
aws <tab>    # worked before
aws pro<tab> # works now
```