### PR TITLE
Remove unnecessary warning

### DIFF
--- a/conf.d/aws.fish
+++ b/conf.d/aws.fish
@@ -1,6 +1,6 @@
 set -e aws_profile
 
 if not set -q aws_completer_path
-  set -g aws_completer_path (type -P aws_completer 2> /dev/null)
-    or echo "aws: unable to find aws_completer, completions unavaliable"
+  command -q aws_completer
+  and set set -g aws_completer_path (command -s aws_completer)
 end


### PR DESCRIPTION
Two changes here:

1. Remove the echo message. I’m in the process of setting up a new computer and have not installed all of the ancillary software, such as `aws_completer`, which means that connections to `sftp` will fail because the shell should not output any messages. In the case that `aws_completer` can’t be found, I suspect that users of this plug-in won’t be able to use the _rest_ of `aws-cli`, either.

2. Remove the need for a redirect to `/dev/null` by checking for `aws_completer` in path by using `command -q`.